### PR TITLE
Fix other issues related to Content Type

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -3,6 +3,8 @@ name: .NET Core
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:

--- a/src/OpenApiContract.Validator/OpenApiContract.Validator.csproj
+++ b/src/OpenApiContract.Validator/OpenApiContract.Validator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <PackageVersion>1.0.0-rc</PackageVersion>
+    <PackageVersion>1.0.0-rc-2</PackageVersion>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>

--- a/src/OpenApiContract.Validator/OpenApiContract.Validator.csproj
+++ b/src/OpenApiContract.Validator/OpenApiContract.Validator.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageVersion>1.0.0-rc</PackageVersion>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenApiContract.Validator/RequestValidator.cs
+++ b/src/OpenApiContract.Validator/RequestValidator.cs
@@ -167,8 +167,7 @@ namespace OpenApiContract.Validator
             if (content == null)
                 return;
 
-            if (!requestBodySpec.Content.TryGetValue(content.Headers.ContentType.ToString(), out OpenApiMediaType mediaTypeSpec))
-                throw new RequestDoesNotMatchSpecException($"Content media type '{content.Headers.ContentType.MediaType}' is not specified");
+            var mediaTypeSpec = ValidateAndExtractOpenApiMediaType(requestBodySpec, content);
 
             try
             {
@@ -182,6 +181,19 @@ namespace OpenApiContract.Validator
             {
                 throw new RequestDoesNotMatchSpecException($"Content does not match spec. {contentException.Message}");
             }
+        }
+
+        private static OpenApiMediaType ValidateAndExtractOpenApiMediaType(OpenApiRequestBody requestBodySpec,
+            HttpContent content)
+        {
+            if (requestBodySpec.Content.TryGetValue(content.Headers.ContentType.MediaType, out var mediaTypeSpec))
+                return mediaTypeSpec;
+            
+            if (requestBodySpec.Content.TryGetValue(content.Headers.ContentType.ToString(), out mediaTypeSpec))
+                return mediaTypeSpec;
+            
+            throw new RequestDoesNotMatchSpecException(
+                $"Neither Content media type '{content.Headers.ContentType.MediaType}' or '{content.Headers.ContentType}' are specified.");
         }
     }
 

--- a/test/OpenApiContract.Validator.Integration.Tests/Integracoes/PetControllerTests.cs
+++ b/test/OpenApiContract.Validator.Integration.Tests/Integracoes/PetControllerTests.cs
@@ -81,9 +81,7 @@ namespace OpenApiContract.Validator.Integration.Tests
             var content = new StringContent(JsonSerializer.Serialize(pet, new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            }));
-            
-            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            }), Encoding.UTF8, "application/json");
             
             var handler = A.Fake<InterceptorFakeHandler>(x => x.CallsBaseMethods());
             A.CallTo(() => handler.FakeSend(A<HttpRequestMessage>._))

--- a/test/OpenApiContract.Validator.Integration.Tests/Integracoes/PetControllerTests.cs
+++ b/test/OpenApiContract.Validator.Integration.Tests/Integracoes/PetControllerTests.cs
@@ -11,7 +11,6 @@ using OpenApiContract.Validator.Interceptors;
 using OpenApiContract.Validator.Api.Models;
 using System.Text.Json;
 using System.Collections.Generic;
-using System.Net.Http.Headers;
 
 namespace OpenApiContract.Validator.Integration.Tests
 {
@@ -82,7 +81,6 @@ namespace OpenApiContract.Validator.Integration.Tests
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             }), Encoding.UTF8, "application/json");
-            
             var handler = A.Fake<InterceptorFakeHandler>(x => x.CallsBaseMethods());
             A.CallTo(() => handler.FakeSend(A<HttpRequestMessage>._))
                 .Returns(new InterceptedResponse
@@ -94,7 +92,6 @@ namespace OpenApiContract.Validator.Integration.Tests
                         Content = new StringContent(Faker.Random.Words(3), Encoding.UTF8, "application/json")
                     }
                 });
-            
             Setup.MeuClient = new HttpClient(handler);
 
             var url = $"{host}/pet";

--- a/test/OpenApiContract.Validator.Integration.Tests/Integracoes/PetControllerTests.cs
+++ b/test/OpenApiContract.Validator.Integration.Tests/Integracoes/PetControllerTests.cs
@@ -11,6 +11,7 @@ using OpenApiContract.Validator.Interceptors;
 using OpenApiContract.Validator.Api.Models;
 using System.Text.Json;
 using System.Collections.Generic;
+using System.Net.Http.Headers;
 
 namespace OpenApiContract.Validator.Integration.Tests
 {
@@ -80,7 +81,10 @@ namespace OpenApiContract.Validator.Integration.Tests
             var content = new StringContent(JsonSerializer.Serialize(pet, new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            }), Encoding.UTF8, "application/json");
+            }));
+            
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            
             var handler = A.Fake<InterceptorFakeHandler>(x => x.CallsBaseMethods());
             A.CallTo(() => handler.FakeSend(A<HttpRequestMessage>._))
                 .Returns(new InterceptedResponse
@@ -92,6 +96,7 @@ namespace OpenApiContract.Validator.Integration.Tests
                         Content = new StringContent(Faker.Random.Words(3), Encoding.UTF8, "application/json")
                     }
                 });
+            
             Setup.MeuClient = new HttpClient(handler);
 
             var url = $"{host}/pet";

--- a/test/OpenApiContract.Validator.Unit.Tests/RequestValidatorTest.cs
+++ b/test/OpenApiContract.Validator.Unit.Tests/RequestValidatorTest.cs
@@ -20,7 +20,7 @@ namespace OpenApiContract.Validator.Unit.Tests
             var openApi = new OpenApiDocumentBuilder()
                 .WithOperation(OperationType.Get)
                 .WithPath(pathTemplate)
-                .WithContentType("application/json")
+                .WithContentType("application/json; v=1")
                 .Build();
 
             var stringContent = new StringContent("{ A: 'B' }");

--- a/test/OpenApiContract.Validator.Unit.Tests/RequestValidatorTest.cs
+++ b/test/OpenApiContract.Validator.Unit.Tests/RequestValidatorTest.cs
@@ -1,26 +1,26 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using NUnit.Framework;
-using MediaTypeHeaderValue = System.Net.Http.Headers.MediaTypeHeaderValue;
 
 namespace OpenApiContract.Validator.Unit.Tests
 {
     public class RequestValidatorTest
     {
         [Test]
-        public void Validate_WhenValidateContentTypeWithVersionSpecification_ShouldBeValidated()
+        public void ValidateContentType_WithVersionInBothSwaggerAndTheRequest_ShouldBeValidated()
         {
             const string pathTemplate = "/path";
-            
+
             var requestValidator = new RequestValidator(new[] {new JsonContentValidator()});
 
             var openApi = new OpenApiDocumentBuilder()
                 .WithOperation(OperationType.Get)
                 .WithPath(pathTemplate)
-                .WithContentType("application/json; v=1")
+                .WithContentType("application/json")
                 .Build();
 
             var stringContent = new StringContent("{ A: 'B' }");
@@ -38,6 +38,122 @@ namespace OpenApiContract.Validator.Unit.Tests
                 pathTemplate);
 
             validate.Should().NotThrow();
+        }
+
+        [Test]
+        public void ValidateContentType_WithoutVersionInSwaggerButWithVersionInTheRequest_ShouldBeValidated()
+        {
+            const string pathTemplate = "/path";
+
+            var requestValidator = new RequestValidator(new[] {new JsonContentValidator()});
+
+            var openApi = new OpenApiDocumentBuilder()
+                .WithOperation(OperationType.Get)
+                .WithPath(pathTemplate)
+                .WithContentType("application/json")
+                .Build();
+
+            var stringContent = new StringContent("{ A: 'B' }");
+            stringContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            stringContent.Headers.ContentType.Parameters.Add(new NameValueHeaderValue("v", "1"));
+
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, pathTemplate)
+            {
+                Content = stringContent
+            };
+
+            Action validate = () => requestValidator.Validate(
+                httpRequestMessage,
+                openApi,
+                pathTemplate);
+
+            validate.Should().NotThrow();
+        }
+
+        [Test]
+        public void ValidateContentType_WithoutEncodingInSwaggerButWithEncodingInTheRequest_ShouldBeValidated()
+        {
+            const string pathTemplate = "/path";
+
+            var requestValidator = new RequestValidator(new[] {new JsonContentValidator()});
+
+            var openApi = new OpenApiDocumentBuilder()
+                .WithOperation(OperationType.Get)
+                .WithPath(pathTemplate)
+                .WithContentType("application/json")
+                .Build();
+
+            var stringContent = new StringContent("{ A: 'B' }", Encoding.UTF8, "application/json");
+
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, pathTemplate)
+            {
+                Content = stringContent
+            };
+
+            Action validate = () => requestValidator.Validate(
+                httpRequestMessage,
+                openApi,
+                pathTemplate);
+
+            validate.Should().NotThrow();
+        }
+
+        [Test]
+        public void ValidateContentType_WithEncodingInBothSwaggerAndRequest_ShouldBeValidated()
+        {
+            const string pathTemplate = "/path";
+
+            var requestValidator = new RequestValidator(new[] {new JsonContentValidator()});
+
+            var openApi = new OpenApiDocumentBuilder()
+                .WithOperation(OperationType.Get)
+                .WithPath(pathTemplate)
+                .WithContentType("application/json; charset=utf-8")
+                .Build();
+
+            var contentWithCharset = new StringContent("{ A: 'B' }", Encoding.UTF8, "application/json");
+
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, pathTemplate)
+            {
+                Content = contentWithCharset
+            };
+
+            Action validate = () => requestValidator.Validate(
+                httpRequestMessage,
+                openApi,
+                pathTemplate);
+
+            validate.Should().NotThrow();
+        }
+
+        [Test]
+        public void ValidateContentType_WithInvalidValues_ShouldThrowExceptionWithCompleteContentTypeAndSimplifiedOne()
+        {
+            const string pathTemplate = "/path";
+
+            var requestValidator = new RequestValidator(new[] {new JsonContentValidator()});
+
+            var openApi = new OpenApiDocumentBuilder()
+                .WithOperation(OperationType.Get)
+                .WithPath(pathTemplate)
+                .WithContentType("application/json; charset=utf-8")
+                .Build();
+
+            var contentIncompatible = new StringContent("{ A: 'B' }", Encoding.UTF8, "text/plain");
+
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, pathTemplate)
+            {
+                Content = contentIncompatible
+            };
+
+            Action validate = () => requestValidator.Validate(
+                httpRequestMessage,
+                openApi,
+                pathTemplate);
+
+            validate.Should().Throw<Exception>()
+                .WithMessage(
+                    "Neither Content media type 'text/plain' or 'text/plain; charset=utf-8' are specified.");
         }
     }
 }


### PR DESCRIPTION
When a request has the Content Type "application/json; charset=utf-8" and the OpenApi document specify only the "application/json" the validation will fail (since the last PR #5).

This PR allows the following scenarios to be validated:
- OpenApi document content-type as "application/json" and the conten-type's request as "application/json; charset=utf-8";
- OpenApi document content-type as "application/json; charset=utf-8" and the conten-type's request as "application/json; charset=utf-8";

